### PR TITLE
Updated release versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,9 @@ pygments: true
 release_base: http://repo.fusesource.com/nexus/content/groups/public/org/fusesource/restygwt/restygwt
 project_name: restygwt
 project_id: resty-gwt
-project_snapshot_version: 1.4-SNAPSHOT
-project_version: 1.4
-project_versions: [1.0,1.1,1.2,1.3]
+project_snapshot_version: 2.0.3-SNAPSHOT
+project_version: 2.0.2
+project_versions: [1.0,1.1,1.2,1.3,1.4,2.0.1,2.0.2]
 git_user_url: git://github.com/chirino/resty-gwt.git
 github_page: https://github.com/resty-gwt/
 issue_tracker: https://github.com/resty-gwt/resty-gwt/issues


### PR DESCRIPTION
This site is badly out of date. This will hopefully update the index and download pages automatically. Do we also want to change the release base to Maven Central? Fixes issue 228 in the main project.