### PR TITLE
Update for release 2.0.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,9 +4,9 @@ pygments: true
 release_base: http://search.maven.org/remotecontent?filepath=org/fusesource/restygwt/restygwt
 project_name: restygwt
 project_id: resty-gwt
-project_snapshot_version: 2.0.3-SNAPSHOT
-project_version: 2.0.2
-project_versions: [1.0,1.1,1.2,1.3,1.3.1,1.4,1.5,2.0,2.0.1,2.0.2]
+project_snapshot_version: 2.0.4-SNAPSHOT
+
+project_versions: [1.0,1.1,1.2,1.3,1.3.1,1.4,1.5,2.0,2.0.1,2.0.2,2.0.3]
 git_user_url: git://github.com/chirino/resty-gwt.git
 github_page: https://github.com/resty-gwt/
 issue_tracker: https://github.com/resty-gwt/resty-gwt/issues

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ project_name: restygwt
 project_id: resty-gwt
 project_snapshot_version: 2.0.3-SNAPSHOT
 project_version: 2.0.2
-project_versions: [1.0,1.1,1.2,1.3,1.4,1.5,2.0.1,2.0.2]
+project_versions: [1.0,1.1,1.2,1.3,1.3.1,1.4,1.5,2.0,2.0.1,2.0.2]
 git_user_url: git://github.com/chirino/resty-gwt.git
 github_page: https://github.com/resty-gwt/
 issue_tracker: https://github.com/resty-gwt/resty-gwt/issues

--- a/download.markdown
+++ b/download.markdown
@@ -3,7 +3,7 @@ layout: default
 title: RestyGWT / Download
 slogan: Download it today!
 ---
-
+{% assign project_version = site.project_versions.last %}
 ## Download
 
 You can download {{site.name}} from the [Maven Repository](http://repo.fusesource.com/nexus/content/repositories/public/) 
@@ -15,7 +15,7 @@ Download latest stable version
 <br/>
 <br/>
 
-[{{site.project_name}}-{{site.project_version}}.jar]({{site.release_base}}/{{site.project_version}}/{{site.project_name}}-{{site.project_version}}.jar)
+[{{site.project_name}}-{{project_version}}.jar]({{site.release_base}}/{{project_version}}/{{site.project_name}}-{{project_version}}.jar)
 
 <br/>
 <br/>
@@ -24,15 +24,15 @@ Previous versions
 <br/>
 <br/>
 
-{% for version in site.project_versions  %}
-
+{% for version in site.project_versions reversed %}
+	{% unless version == site.project_versions.last %}
 - [{{site.project_name}}-{{version}}.jar]({{site.release_base}}/{{version}}/{{site.project_name}}-{{version}}.jar)
-
+	{% endunless %}
 {% endfor %}
 
 ## Snapshots
 
-Want to help stablize the latest and greatest nightly development build? **Warnning**: This build may be extremely bleeding edge!
+Want to help stabilize the latest and greatest nightly development build? **Warning**: This build may be extremely bleeding edge!
 <br/>
 <br/>
 Latest version : 
@@ -52,7 +52,7 @@ If you are a maven user, then just add the following dependency to your `pom.xml
 <dependency>
     <groupId>org.fusesource.{{site.project_name}}</groupId>
     <artifactId>{{site.project_name}}</artifactId>
-    <version>{{site.project_version}}</version>
+    <version>{{project_version}}</version>
 </dependency>
 {% endhighlight %}
 

--- a/index.markdown
+++ b/index.markdown
@@ -2,7 +2,7 @@
 layout: index
 title: RestyGWT
 ---
-
+{% assign project_version = site.project_versions.last %}
 <div class="jumbotron">
 	<div class="logo">
       <img src="/images/restygwt-logo.png" alt="RestyGWT logo">
@@ -17,17 +17,17 @@ title: RestyGWT
 <br/><br/>
 
 <img src="/images/gwt-create-logo.svg"/><br/><br/>
-Full room for RestyGwt + Jersey presentation by David Chandler @GwtCreate 2015, amazing !</br><br/>
+Full room for RestyGwt + Jersey presentation by David Chandler @GwtCreate 2015, amazing !<br/><br/>
 
 <img width="330px" src="/images/gwtcreate1.jpg"/><img width="330px" src="/images/gwtcreate2.jpg"/>
-</br><br/>
+<br/><br/>
 
 <i class="fa fa-circle number"><span class="number">1</span><span class="text">Add RestyGWT to your classpath</span></i>
 <br/><br/>
 Download the latest stable RestyGWT jar
 <br/><br/>
 
-- [{{site.project_name}}-{{site.project_version}}.jar]({{site.release_base}}/{{site.project_version}}/{{site.project_name}}-{{site.project_version}}.jar)
+- [{{site.project_name}}-{{project_version}}.jar]({{site.release_base}}/{{project_version}}/{{site.project_name}}-{{project_version}}.jar)
 
 Or if you are a maven user, then just add the following dependency to your `pom.xml`.
 <br/><br/>
@@ -36,7 +36,7 @@ Or if you are a maven user, then just add the following dependency to your `pom.
 <dependency>
     <groupId>org.fusesource.{{site.project_name}}</groupId>
     <artifactId>{{site.project_name}}</artifactId>
-    <version>{{site.project_version}}</version>
+    <version>{{project_version}}</version>
 </dependency>
 {% endhighlight %}
 


### PR DESCRIPTION
- add version [2.0.3](https://github.com/resty-gwt/resty-gwt/commit/0ce783c2d4b958ae661d2713eb8bf66536cd6427)
- use last from project_versions as the project_version
- fix some typos
- list release versions in descending order
- add two previous versions
